### PR TITLE
Add task modal

### DIFF
--- a/kanban-ui/src/App.tsx
+++ b/kanban-ui/src/App.tsx
@@ -2,19 +2,21 @@ import AppShell from "./components/AppShell/AppShell";
 import dummyData from "./dummyData.json";
 import styles from "./App.module.css";
 import Column from "./components/Column/Column";
-import Modal from "./components/Modal/Modal";
 import { useState } from "react";
+import ViewTaskModal from "./components/ViewTaskModal/ViewTaskModal";
 
 const App = () => {
-  const [open, setOpen] = useState<boolean>(true);
+  const [viewTaskModal, setViewtaskModal] = useState<boolean>(true);
 
-  const handleToggleModal = () => {
-    setOpen(!open);
+  const handleToggleViewTaskModal = () => {
+    setViewtaskModal(!viewTaskModal);
   };
 
   return (
     <AppShell>
-      {open && <Modal toggleModal={handleToggleModal}>Modal</Modal>}
+      {viewTaskModal && (
+        <ViewTaskModal toggleModal={handleToggleViewTaskModal} />
+      )}
       {dummyData.colData ? (
         <div className={styles.mainContainer}>
           {dummyData.colData.map((col) => (

--- a/kanban-ui/src/components/CheckBox/CheckBox.module.css
+++ b/kanban-ui/src/components/CheckBox/CheckBox.module.css
@@ -6,7 +6,6 @@
   padding: 12px;
   border-radius: 4px;
   cursor: pointer;
-  max-width: 350px;
   font-weight: bold;
 }
 

--- a/kanban-ui/src/components/DownDown/DropDown.module.css
+++ b/kanban-ui/src/components/DownDown/DropDown.module.css
@@ -1,5 +1,4 @@
 .container {
-  width: 350px;
 }
 
 .button {

--- a/kanban-ui/src/components/Modal/Modal.module.css
+++ b/kanban-ui/src/components/Modal/Modal.module.css
@@ -5,7 +5,7 @@
   left: 0;
   right: 0;
   z-index: 10;
-  background-color: red;
+  background-color: rgba(var(--dark-gray), 0.6);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -18,6 +18,9 @@
   width: 100%;
   margin: 16px;
   z-index: 12;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
 @media screen and (min-width: 680px) {

--- a/kanban-ui/src/components/ViewTaskModal/ViewTaskModal.module.css
+++ b/kanban-ui/src/components/ViewTaskModal/ViewTaskModal.module.css
@@ -1,0 +1,24 @@
+.heading {
+}
+
+.description {
+  color: rgba(var(--blue-gray), 1);
+  font-weight: bold;
+}
+
+.subTaskContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.subTaskLabel {
+  color: rgba(var(--blue-gray), 1);
+  font-weight: bold;
+}
+
+.dropDownLabel {
+  margin-bottom: 8px;
+  color: rgba(var(--blue-gray), 1);
+  font-weight: bold;
+}

--- a/kanban-ui/src/components/ViewTaskModal/ViewTaskModal.tsx
+++ b/kanban-ui/src/components/ViewTaskModal/ViewTaskModal.tsx
@@ -1,0 +1,56 @@
+import CheckBox from "../CheckBox/CheckBox";
+import DropDown from "../DownDown/DropDown";
+import Modal from "../Modal/Modal";
+import styles from "./ViewTaskModal.module.css";
+
+interface ViewTaskModalProps {
+  toggleModal: () => void;
+}
+
+const ViewTaskModal = ({ toggleModal }: ViewTaskModalProps) => {
+  const sub = 1;
+
+  return (
+    <Modal toggleModal={toggleModal}>
+      <h2 className={`${styles.heading} heading-lg`}>MODAL HEADING</h2>
+      <p className={`${styles.description} text-lg`}>
+        This is where the description of the task goes. It will be a few
+        sentences that explain what the core task is and how it needs to be
+        completed.
+      </p>
+      <div className={styles.subTaskContainer}>
+        <div className={styles.subTaskLabel}>
+          Subtasks ({sub} of {sub})
+        </div>
+        <CheckBox
+          label="Subtask Number One"
+          checked={false}
+          taskId="123"
+          onChange={() => {}}
+        />
+        <CheckBox
+          label="Subtask Number One"
+          checked={false}
+          taskId="123"
+          onChange={() => {}}
+        />
+        <CheckBox
+          label="Subtask Number One"
+          checked={false}
+          taskId="123"
+          onChange={() => {}}
+        />
+      </div>
+      <div>
+        <div className={styles.dropDownLabel}>Current Status</div>
+        <DropDown
+          values={["Doing", "Done"]}
+          value="Doing"
+          setValue={() => {}}
+        />
+      </div>
+    </Modal>
+  );
+};
+
+export default ViewTaskModal;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/518caeef-bc0c-429d-a0ef-13c759684647)

Adds a view task modal that opens to show the task details. This includes a generic modal system that can be used for all modals in the app, and a custom implementation of the task specific modal using the generic base.